### PR TITLE
Fixed typo in K8s-Taint-Toleration.md file

### DIFF
--- a/K8s-Taint-Toleration.md
+++ b/K8s-Taint-Toleration.md
@@ -26,8 +26,8 @@ spec:
   containers:
   - name: toleratedcontainer1
     image: nginx:latest
-  tolerations:                    # pod tolerates "app=production:NoSchedule"
-  - key: "app"
+  tolerations:                    # pod tolerates "platform=production:NoSchedule"
+  - key: "platform"
     operator: "Equal"
     value: "production"
     effect: "NoSchedule"
@@ -43,8 +43,8 @@ spec:
   - name: toleratedcontainer2
     image: nginx:latest
   tolerations:
-  - key: "app"                     # pod tolerates "app:NoSchedule", value is not important in this pod
-    operator: "Exists"             # pod can run on the nodes which has "app=test:NoSchedule" or "app=production:NoSchedule"
+  - key: "platform"                     # pod tolerates "platform:NoSchedule", value is not important in this pod
+    operator: "Exists"             # pod can run on the nodes which has "platform=test:NoSchedule" or "platform=production:NoSchedule"
     effect: "NoSchedule" 
 ```
 


### PR DESCRIPTION
K8s-Taint-Toleration.md file put the toleration key as "app" for both pods, when they should be "platform" to match the given .yaml as well as the rest of the .md guide.